### PR TITLE
Added simple URL parser to simplify setup

### DIFF
--- a/custom_components/bosch_ebike/config_flow.py
+++ b/custom_components/bosch_ebike/config_flow.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any
 
 import voluptuous as vol
+from urllib.parse import urlparse, parse_qs
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_ACCESS_TOKEN
@@ -87,6 +88,14 @@ class BoschEBikeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         # Extract authorization code from user input
         authorization_code = user_input[CONF_CODE].strip()
+
+        # The user might have pasted the complete URL... so we try to parse it
+        if "code=" in authorization_code:
+            query_params = parse_qs(urlparse(authorization_code).query)
+            if "code" not in query_params:
+                return self.async_abort(reason="missing_code")
+            else:
+                authorization_code = query_params["code"][0]
 
         # Get code_verifier from context
         code_verifier = self.context.get("code_verifier")


### PR DESCRIPTION
Hi,

I am marq24 also developing some HA integrations... In your current setup you request the user to enter the code captured during the OAuth Flow... (I do something similar here: https://github.com/marq24/ha-fordpass/blob/main/doc/OBTAINING_TOKEN.md

My experience is, that users struggle quite a lot with the copy of the correct part of the URL - so in the PR the user input will be taken and the code will be parsed automatically - this IMHO simplify the setup - since you only have to request your users to copy the complete URL of the final (failing) request to `onebikeapp-ios://com.bosch.ebike.onebikeapp/oauth2redirect?code=....` 